### PR TITLE
Fix for $this in Cache closure.

### DIFF
--- a/src/Fuhrmann/LarageoPlugin/LarageoPlugin.php
+++ b/src/Fuhrmann/LarageoPlugin/LarageoPlugin.php
@@ -23,10 +23,12 @@ class LarageoPlugin {
         $url = str_replace('{IP}', $ip, $this->api_adress);
         $subnet = substr($ip, 0, strrpos ($ip, '.'));
 
+        $me = $this;
+
         // Use the IP info stored in cache or store it
-        $ipInfo = Cache::remember($subnet, 10080, function() use ($url)
+        $ipInfo = Cache::remember($subnet, 10080, function() use ($me, $url)
         {
-            return $this->fetchInfo($url);
+            return $me->fetchInfo($url);
         });
 
         return $ipInfo;
@@ -73,7 +75,7 @@ class LarageoPlugin {
      * @throws \Exception
      * @return mixed
      */
-    protected function fetchInfo($url) {
+    public function fetchInfo($url) {
         $response = null;
 
         if (function_exists('curl_init')) {
@@ -105,5 +107,3 @@ class LarageoPlugin {
         return $response;
     }
 }
-
-


### PR DESCRIPTION
$this is not permited in a closure in PHP 5.3. This workaround solves this issue.
Please feel free to change it if you know a better solution.

Cheers,
MichMich.
