### PR TITLE
Documentation actualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,19 +22,19 @@ Next, run the Composer update comand
 Add the service provider to app/config/app.php, within the providers array.
 
 ```php
-    'providers' => array(
+    'providers' => [
         // ...
         'Fuhrmann\LarageoPlugin\ServiceProvider',
-    ),
+    ],
 ```
 
 In the same file `config/app.php` add the alias:
 
 ```php
-    'aliases' => array(
+    'aliases' => [
         //...
         'LarageoPlugin'   => 'Fuhrmann\LarageoPlugin\Facade',
-    ),
+    ],
 ```
 
 ### Usage
@@ -42,14 +42,14 @@ In the same file `config/app.php` add the alias:
 You can specify an IP:
 
 ```php
-    $info = LarageoPlugin::getInfo('177.34.13.248'); // get info from a IP
+    $info = LarageoPlugin->getInfo('177.34.13.248'); // get info from a IP
     var_dump($info);
 ```
 
 Or use it without any param:
 
 ```php
-    $info = LarageoPlugin::getInfo(); // get info from the IP of the user acessing the page
+    $info = LarageoPlugin->getInfo(); // get info from the IP of the user acessing the page
     var_dump($info);
 ```
 
@@ -80,7 +80,7 @@ This is the output:
 Another useful example: You can also just return one field, e.g. city from in one call:
 
 ```php
-    $userCity = LarageoPlugin::getInfo()->geoplugin_city; // get the city from the user IP
+    $userCity = LarageoPlugin->getInfo()->geoplugin_city; // get the city from the user IP
     var_dump($userCity);
 ```
 


### PR DESCRIPTION
Documentation actualization. Laravel doesn´t use the array() method anymore for Aliases and Providers, just [], so it was changed that way.
Also, the getInfo() method is not static, and calling it this way causes an error in Laravel. (In PHP raw may work, but it is not recomendable to do it anyway) So it was changed from the :: operator to ->